### PR TITLE
Add documentation comments to turbine and wind farm

### DIFF
--- a/include/turbine.h
+++ b/include/turbine.h
@@ -1,0 +1,103 @@
+/*
+ * MicroHH
+ * Copyright (c) 2011-2024 Chiel van Heerwaarden
+ * Copyright (c) 2011-2024 Thijs Heus
+ * Copyright (c) 2014-2024 Bart van Stratum
+ *
+ * This file is part of MicroHH
+ *
+ * MicroHH is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MicroHH is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MicroHH.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef TURBINE_H
+#define TURBINE_H
+
+#include <vector>
+#include <string>
+
+class Master;
+class Input;
+template<typename> class Grid;
+template<typename> class Fields;
+template<typename> class Stats;
+
+/**
+ * Simple actuator disk turbine model.
+ * Reads the following parameters from (case).ini file
+ *
+ * [turbine]
+ * diam            ; turbine diameter (m)
+ * hhub            ; hub height (m)
+ * ct              ; thrust coefficient
+ * cp              ; power coefficient
+ * tsr             ; tip speed ratio
+ * swdynyaw        ; enable dynamic yaw control
+ * yawperiod       ; yaw period (s)
+ * turbstarttime   ; start time for turbines (s)
+ * swturbstats     ; enable turbine statistics
+ * turbstatperiod  ; period for turbine statistics (s)
+ */
+
+template<typename TF>
+class Turbine
+{
+    public:
+        Turbine(Master&, Grid<TF>&, Fields<TF>&, Input&, TF, TF, TF);
+        ~Turbine();
+
+        void create();                ///< Setup turbine parameters.
+        void exec(Stats<TF>&, double);///< Apply turbine forcing.
+
+        TF get_power() const { return power; }
+
+        // GPU interface
+        void prepare_device();
+        void clear_device();
+
+    private:
+        Master& master;  ///< Reference to global simulation controller
+        Grid<TF>& grid;  ///< LES grid description
+        Fields<TF>& fields; ///< Flow field container
+
+        TF diam;         ///< Rotor diameter (m)
+        TF hhub;         ///< Hub height (m)
+        TF ct;           ///< Thrust coefficient
+        TF cp;           ///< Power coefficient
+        TF tsr;          ///< Tip speed ratio
+        bool swdynyaw;   ///< Enable dynamic yaw control
+        TF yawperiod;    ///< Yaw update period (s)
+        TF turbstarttime;///< Start time for turbine forcing (s)
+        bool swturbstats;///< Enable turbine statistics output
+        TF turbstatperiod;///< Statistics output period (s)
+
+        // Runtime parameters
+        TF xpos;         ///< Turbine x-position (m)
+        TF ypos;         ///< Turbine y-position (m)
+        TF yaw;          ///< Current yaw angle (rad)
+        TF next_yaw;     ///< Next time to update yaw (s)
+        TF area;         ///< Disk area (m^2)
+        int k_hub;       ///< Grid index of hub height
+
+        std::vector<int> indices; ///< Grid indices covered by disk
+        std::vector<TF> weights;  ///< Corresponding Gaussian weights
+
+        TF power;        ///< Instantaneous turbine power (W)
+
+        // GPU containers
+        #ifdef USECUDA
+        cuda_vector<TF> dummy_g; ///< placeholder for future GPU data
+        #endif
+};
+
+#endif

--- a/include/windfarm.h
+++ b/include/windfarm.h
@@ -1,0 +1,87 @@
+/*
+ * MicroHH
+ * Copyright (c) 2011-2024 Chiel van Heerwaarden
+ * Copyright (c) 2011-2024 Thijs Heus
+ * Copyright (c) 2014-2024 Bart van Stratum
+ *
+ * This file is part of MicroHH
+ *
+ * MicroHH is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MicroHH is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MicroHH.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef WINDFARM_H
+#define WINDFARM_H
+
+#include <vector>
+#include <string>
+#include "turbine.h"
+
+class Master;
+class Input;
+template<typename> class Grid;
+template<typename> class Fields;
+template<typename> class Stats;
+
+/**
+ * Wind farm manager class that configures multiple turbines.
+ * Reads the following parameters from (case).ini file
+ *
+ * [windfarm]
+ * nturbrows   ; number of turbine rows
+ * nturbcols   ; number of turbine columns
+ * spacingx    ; row spacing (x direction) (D)
+ * spacingy    ; column spacing (y direction) (D)
+ * swstaggered ; enable staggered layout
+ * farmlocx    ; farm location x (m)
+ * farmlocy    ; farm location y (m)
+ */
+
+template<typename TF>
+class Windfarm
+{
+    public:
+        Windfarm(Master&, Grid<TF>&, Fields<TF>&, Input&);
+        ~Windfarm();
+
+        void create();                ///< Setup wind farm layout.
+        void exec(Stats<TF>&, double);///< Apply turbine forcing for all turbines.
+
+        TF get_farm_power() const { return farm_power; }
+
+        void prepare_device();
+        void clear_device();
+
+    private:
+        Master& master;   ///< Global simulation controller
+        Grid<TF>& grid;   ///< LES grid description
+        Fields<TF>& fields; ///< Flow field container
+        Input& input;     ///< Input file handle
+
+        int nturbrows;    ///< Number of rows in the farm
+        int nturbcols;    ///< Number of columns in the farm
+        TF spacingx;      ///< Row spacing in diameters
+        TF spacingy;      ///< Column spacing in diameters
+        bool swstaggered; ///< Whether layout uses staggered rows
+        TF farmlocx;      ///< Starting x location of farm (m)
+        TF farmlocy;      ///< Starting y location of farm (m)
+        std::string layoutfile; ///< Optional manual layout file
+
+        TF diam;          ///< Turbine diameter (m)
+        
+        TF farm_power;    ///< Aggregate power output (W)
+
+        std::vector<Turbine<TF>> turbines; ///< Container of turbines
+};
+
+#endif

--- a/src/turbine.cu
+++ b/src/turbine.cu
@@ -1,0 +1,29 @@
+/*
+ * MicroHH
+ * Copyright (c) 2011-2024 Chiel van Heerwaarden
+ * Copyright (c) 2011-2024 Thijs Heus
+ * Copyright (c) 2014-2024 Bart van Stratum
+ *
+ * This file is part of MicroHH
+ *
+ * MicroHH is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MicroHH is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MicroHH.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "turbine.h"
+
+#ifdef USECUDA
+
+// Placeholder for future GPU kernels related to turbine forcing and yaw updates
+
+#endif

--- a/src/turbine.cxx
+++ b/src/turbine.cxx
@@ -1,0 +1,214 @@
+/*
+ * MicroHH
+ * Copyright (c) 2011-2024 Chiel van Heerwaarden
+ * Copyright (c) 2011-2024 Thijs Heus
+ * Copyright (c) 2014-2024 Bart van Stratum
+ *
+ * This file is part of MicroHH
+ *
+ * MicroHH is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MicroHH is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MicroHH.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "turbine.h"
+#include "master.h"
+#include "grid.h"
+#include "fields.h"
+#include "input.h"
+#include "stats.h"
+#include <numeric>
+#include <cmath>
+
+template<typename TF>
+Turbine<TF>::Turbine(Master& masterin, Grid<TF>& gridin, Fields<TF>& fieldsin,
+                     Input& input, TF xin, TF yin, TF hhub_in) :
+    master(masterin), grid(gridin), fields(fieldsin)
+{
+    // Retrieve turbine parameters from input file
+    diam          = input.get_item<TF>("turbine", "diam", "");
+    hhub          = input.get_item<TF>("turbine", "hhub", "");
+    ct            = input.get_item<TF>("turbine", "ct", "");
+    cp            = input.get_item<TF>("turbine", "cp", "");
+    tsr           = input.get_item<TF>("turbine", "tsr", "");
+    swdynyaw      = input.get_item<bool>("turbine", "swdynyaw", "", false);
+    yawperiod     = input.get_item<TF>("turbine", "yawperiod", "", TF(0));
+    turbstarttime = input.get_item<TF>("turbine", "turbstarttime", "", TF(0));
+    swturbstats   = input.get_item<bool>("turbine", "swturbstats", "", false);
+    turbstatperiod= input.get_item<TF>("turbine", "turbstatperiod", "", TF(0));
+
+    // Allow override of hub height from layout file
+    if (hhub_in > TF(0))
+        hhub = hhub_in;
+
+    xpos = xin;
+    ypos = yin;
+    yaw  = 0;
+    next_yaw = turbstarttime;
+    // Precompute rotor disk area
+    area = M_PI * diam * diam * TF(0.25);
+    power = 0;
+}
+
+template<typename TF>
+Turbine<TF>::~Turbine()
+{
+}
+
+template<typename TF>
+void Turbine<TF>::create()
+{
+    auto& gd = grid.get_grid_data();
+
+    // Determine vertical index closest to hub height
+    k_hub = gd.kstart;
+    TF minz = std::abs(gd.z[gd.kstart] - hhub);
+    for (int k=gd.kstart+1; k<gd.kend; ++k)
+    {
+        TF diff = std::abs(gd.z[k] - hhub);
+        if (diff < minz)
+        {
+            minz = diff;
+            k_hub = k;
+        }
+    }
+
+    // Gaussian filter width based on grid spacing
+    TF Delta = TF(1.5) * gd.dx; // assume uniform spacing
+    TF radius = diam * TF(0.5); // rotor radius
+
+    const int jj = gd.jstride;
+    const int kk = gd.kstride;
+
+    // Arrays of grid indices and weights that cover the disk
+    indices.clear();
+    weights.clear();
+
+    for (int j=gd.jstart; j<gd.jend; ++j)
+        for (int i=gd.istart; i<gd.iend; ++i)
+        {
+            // Distance of cell centre to turbine
+            TF dx = gd.x[i] - xpos;
+            TF dy = gd.y[j] - ypos;
+            TF r2 = dx*dx + dy*dy;
+            if (std::sqrt(r2) <= radius)
+            {
+                // Store flattened index and Gaussian weight
+                indices.push_back(i + j*jj + k_hub*kk);
+                weights.push_back(std::exp(-6.*r2/(Delta*Delta)));
+            }
+        }
+
+    // Normalise weights so they sum to one
+    TF wsum = std::accumulate(weights.begin(), weights.end(), TF(0));
+    if (wsum > TF(0))
+        for (auto& w : weights)
+            w /= wsum;
+}
+
+template<typename TF>
+void Turbine<TF>::exec(Stats<TF>&, double time)
+{
+    // Skip forcing until turbine start time
+    if (time < turbstarttime)
+        return;
+
+    // Access velocity fields and grid information
+    auto& u = fields.mp.at("u")->fld;
+    auto& v = fields.mp.at("v")->fld;
+    auto& gd = grid.get_grid_data();
+
+    const int jj = gd.jstride;
+    const int kk = gd.kstride;
+
+    // Update yaw based on upstream flow measurement
+    if (swdynyaw && time >= next_yaw)
+    {
+        // find cell one diameter upstream of current yaw
+        TF xref = xpos - diam * std::cos(yaw);
+        TF yref = ypos - diam * std::sin(yaw);
+
+        auto nearest_index = [](TF val, const std::vector<TF>& arr, int s, int e)
+        {
+            int idx = s;
+            TF md = std::abs(arr[s] - val);
+            for (int i=s+1; i<e; ++i)
+            {
+                TF d = std::abs(arr[i] - val);
+                if (d < md)
+                {
+                    md = d;
+                    idx = i;
+                }
+            }
+            return idx;
+        };
+
+        int iu = nearest_index(xref, gd.x, gd.istart, gd.iend);
+        int ju = nearest_index(yref, gd.y, gd.jstart, gd.jend);
+        int idx = iu + ju*jj + k_hub*kk;
+
+        TF ur = u[idx];
+        TF vr = v[idx];
+
+        TF target = std::atan2(vr, ur);      // target wind direction
+        yaw += (target - yaw) * TF(0.2);      // relax toward target
+
+        next_yaw += yawperiod;
+    }
+
+    // Calculate disk-averaged incoming velocity
+    TF umean = 0;
+    for (size_t n=0; n<indices.size(); ++n)
+    {
+        int idx = indices[n];
+        umean += weights[n] * (u[idx]*std::cos(yaw) + v[idx]*std::sin(yaw));
+    }
+
+    // Compute thrust force and power from disk-averaged velocity
+    TF thrust = 0.5 * ct * umean * std::abs(umean);
+    TF powloc = cp * 0.5 * umean * umean * umean * area;
+    power = powloc;
+
+    // Apply actuator disk forcing to all covered cells
+    for (size_t n=0; n<indices.size(); ++n)
+    {
+        int idx = indices[n];
+        TF f = thrust * weights[n];
+        u[idx] -= f * std::cos(yaw);
+        v[idx] -= f * std::sin(yaw);
+    }
+}
+
+template<typename TF>
+void Turbine<TF>::prepare_device()
+{
+#ifdef USECUDA
+    // Allocate GPU resources (placeholder)
+    dummy_g.allocate(1);
+#endif
+}
+
+template<typename TF>
+void Turbine<TF>::clear_device()
+{
+#ifdef USECUDA
+    // Release GPU resources (placeholder)
+    dummy_g.clear();
+#endif
+}
+
+#ifdef FLOAT_SINGLE
+template class Turbine<float>;
+#else
+template class Turbine<double>;
+#endif

--- a/src/windfarm.cu
+++ b/src/windfarm.cu
@@ -1,0 +1,29 @@
+/*
+ * MicroHH
+ * Copyright (c) 2011-2024 Chiel van Heerwaarden
+ * Copyright (c) 2011-2024 Thijs Heus
+ * Copyright (c) 2014-2024 Bart van Stratum
+ *
+ * This file is part of MicroHH
+ *
+ * MicroHH is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MicroHH is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MicroHH.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "windfarm.h"
+
+#ifdef USECUDA
+
+// Placeholder for future GPU kernels related to farm-level operations
+
+#endif

--- a/src/windfarm.cxx
+++ b/src/windfarm.cxx
@@ -1,0 +1,130 @@
+/*
+ * MicroHH
+ * Copyright (c) 2011-2024 Chiel van Heerwaarden
+ * Copyright (c) 2011-2024 Thijs Heus
+ * Copyright (c) 2014-2024 Bart van Stratum
+ *
+ * This file is part of MicroHH
+ *
+ * MicroHH is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MicroHH is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MicroHH.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "windfarm.h"
+#include "master.h"
+#include "grid.h"
+#include "fields.h"
+#include "input.h"
+#include "stats.h"
+#include <fstream>
+#include <stdexcept>
+
+template<typename TF>
+Windfarm<TF>::Windfarm(Master& masterin, Grid<TF>& gridin, Fields<TF>& fieldsin, Input& inputin) :
+    master(masterin), grid(gridin), fields(fieldsin), input(inputin)
+{
+    // Read wind farm layout parameters
+    nturbrows  = inputin.get_item<int>("windfarm", "nturbrows", "", 1);
+    nturbcols  = inputin.get_item<int>("windfarm", "nturbcols", "", 1);
+    spacingx   = inputin.get_item<TF>("windfarm", "spacingx", "", TF(0));
+    spacingy   = inputin.get_item<TF>("windfarm", "spacingy", "", TF(0));
+    swstaggered= inputin.get_item<bool>("windfarm", "swstaggered", "", false);
+    farmlocx   = inputin.get_item<TF>("windfarm", "farmlocx", "", TF(0));
+    farmlocy   = inputin.get_item<TF>("windfarm", "farmlocy", "", TF(0));
+    layoutfile = inputin.get_item<std::string>("windfarm", "layoutfile", "", "");
+    diam       = inputin.get_item<TF>("turbine", "diam", "");
+    farm_power = 0; // initialise aggregate power
+}
+
+template<typename TF>
+Windfarm<TF>::~Windfarm()
+{
+}
+
+template<typename TF>
+void Windfarm<TF>::create()
+{
+    // Remove existing turbine list
+    turbines.clear();
+
+    auto& gd = grid.get_grid_data();
+
+    // Helper lambda to create a single turbine
+    auto add_turb = [&](TF x, TF y, TF hh)
+    {
+        if (x - 0.5*diam < 0 || x + 0.5*diam > gd.xsize ||
+            y - 0.5*diam < 0 || y + 0.5*diam > gd.ysize)
+            throw std::runtime_error("Turbine near boundary");
+
+        turbines.emplace_back(master, grid, fields, input, x, y, hh);
+        turbines.back().create();
+    };
+
+    // Option 1: read turbine positions from external file
+    if (!layoutfile.empty())
+    {
+        std::ifstream f(layoutfile);
+        if (!f.is_open())
+            throw std::runtime_error("Cannot open layout file " + layoutfile);
+        TF x, y, hh;
+        while (f >> x >> y >> hh)
+            add_turb(x, y, hh);
+    }
+    else
+    {
+        // Option 2: generate regular grid of turbines
+        for (int r=0; r<nturbrows; ++r)
+        {
+            TF y = farmlocy + r*spacingy*diam;
+            for (int c=0; c<nturbcols; ++c)
+            {
+                TF offset = (swstaggered && (r%2==1)) ? 0.5*spacingx*diam : TF(0);
+                TF x = farmlocx + c*spacingx*diam + offset;
+                add_turb(x, y, -1);
+            }
+        }
+    }
+}
+
+template<typename TF>
+void Windfarm<TF>::exec(Stats<TF>& stats, double time)
+{
+    farm_power = 0; // reset accumulator
+    for (auto& t : turbines)
+    {
+        t.exec(stats, time);
+        farm_power += t.get_power();
+    }
+}
+
+template<typename TF>
+void Windfarm<TF>::prepare_device()
+{
+    // Allocate GPU data for all turbines
+    for (auto& t : turbines)
+        t.prepare_device();
+}
+
+template<typename TF>
+void Windfarm<TF>::clear_device()
+{
+    // Clear GPU data for all turbines
+    for (auto& t : turbines)
+        t.clear_device();
+}
+
+#ifdef FLOAT_SINGLE
+template class Windfarm<float>;
+#else
+template class Windfarm<double>;
+#endif


### PR DESCRIPTION
## Summary
- clarify actuator disk turbine members with inline comments
- document wind farm layout parameters and runtime data
- explain turbine initialization and force application steps
- add notes in CUDA stubs for future GPU kernels

## Testing
- `cmake ..` *(fails: Config file config/default.cmake does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_685afec0fab8832a9dd73cffc68e7c84