### PR TITLE
Integrate wind farm model

### DIFF
--- a/include/model.h
+++ b/include/model.h
@@ -51,6 +51,7 @@ template<typename> class Thermo;
 template<typename> class Microphys;
 template<typename> class Radiation;
 template<typename> class Land_surface;
+template<typename> class Windfarm;
 
 template<typename> class Decay;
 template<typename> class Limiter;
@@ -109,6 +110,7 @@ class Model
         std::shared_ptr<Source<TF>> source;
 
         std::shared_ptr<Particle_bin<TF>> particle_bin;
+        std::shared_ptr<Windfarm<TF>> windfarm;
 
         std::shared_ptr<Stats<TF>> stats;
         std::shared_ptr<Budget<TF>> budget;


### PR DESCRIPTION
## Summary
- expose `Windfarm` class in `Model`
- construct and initialize a wind farm within the model
- apply turbine forcing during the time loop
- support GPU preparation/cleanup for wind farm data
