### PR TITLE
Add drag disk forcing module

### DIFF
--- a/include/dragdisk.h
+++ b/include/dragdisk.h
@@ -1,0 +1,81 @@
+/*
+ * MicroHH
+ * Copyright (c) 2011-2024 Chiel van Heerwaarden
+ * Copyright (c) 2011-2024 Thijs Heus
+ * Copyright (c) 2014-2024 Bart van Stratum
+ *
+ * This file is part of MicroHH
+ *
+ * MicroHH is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MicroHH is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MicroHH.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef DRAGDISK_H
+#define DRAGDISK_H
+
+#include <vector>
+
+class Master;
+class Input;
+template<typename> class Grid;
+template<typename> class Fields;
+template<typename> class Stats;
+
+/**
+ * Simple rectangular drag disk that applies a linear damping force
+ * to the streamwise velocity inside a specified region.
+ *
+ * Parameters read from (case).ini:
+ *
+ * [dragdisk]
+ * sizex   ; number of grid cells in x-direction
+ * sizey   ; number of grid cells in y-direction
+ * height  ; height of disk centre (m)
+ * cd      ; drag coefficient (s^-1, optional, default 0.2)
+ */
+
+template<typename TF>
+class DragDisk
+{
+    public:
+        DragDisk(Master&, Grid<TF>&, Fields<TF>&, Input&);
+        ~DragDisk();
+
+        void create();                ///< Setup drag disk indices.
+        void exec(Stats<TF>&, double);///< Apply drag forcing.
+
+        // GPU interface (placeholders)
+        void prepare_device();
+        void clear_device();
+
+    private:
+        Master& master;  ///< Reference to master controller
+        Grid<TF>& grid;  ///< Computational grid
+        Fields<TF>& fields; ///< Flow fields
+
+        int sizex;   ///< number of cells in x-direction
+        int sizey;   ///< number of cells in y-direction
+        TF height;   ///< disk centre height
+        TF cd;       ///< drag coefficient
+        bool enabled;///< switch for drag disk
+
+        int k_center;             ///< vertical index of disk
+        std::vector<int> indices; ///< flattened grid indices inside disk
+
+        #ifdef USECUDA
+        // Placeholder for potential GPU data
+        cuda_vector<int> dummy_g;
+        #endif
+};
+
+#endif

--- a/include/model.h
+++ b/include/model.h
@@ -51,6 +51,7 @@ template<typename> class Thermo;
 template<typename> class Microphys;
 template<typename> class Radiation;
 template<typename> class Land_surface;
+template<typename> class DragDisk;
 template<typename> class Windfarm;
 
 template<typename> class Decay;
@@ -110,6 +111,7 @@ class Model
         std::shared_ptr<Source<TF>> source;
 
         std::shared_ptr<Particle_bin<TF>> particle_bin;
+        std::shared_ptr<DragDisk<TF>> dragdisk;
         std::shared_ptr<Windfarm<TF>> windfarm;
 
         std::shared_ptr<Stats<TF>> stats;

--- a/src/dragdisk.cu
+++ b/src/dragdisk.cu
@@ -1,0 +1,27 @@
+/*
+ * MicroHH
+ * Copyright (c) 2011-2024 Chiel van Heerwaarden
+ * Copyright (c) 2011-2024 Thijs Heus
+ * Copyright (c) 2014-2024 Bart van Stratum
+ *
+ * This file is part of MicroHH
+ *
+ * MicroHH is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MicroHH is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MicroHH.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "dragdisk.h"
+
+#ifdef USECUDA
+// Placeholder for future GPU implementation of drag disk forcing.
+#endif

--- a/src/dragdisk.cxx
+++ b/src/dragdisk.cxx
@@ -1,0 +1,119 @@
+/*
+ * MicroHH
+ * Copyright (c) 2011-2024 Chiel van Heerwaarden
+ * Copyright (c) 2011-2024 Thijs Heus
+ * Copyright (c) 2014-2024 Bart van Stratum
+ *
+ * This file is part of MicroHH
+ *
+ * MicroHH is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MicroHH is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MicroHH.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "dragdisk.h"
+#include "master.h"
+#include "grid.h"
+#include "fields.h"
+#include "input.h"
+#include "stats.h"
+#include <algorithm>
+#include <cmath>
+
+template<typename TF>
+DragDisk<TF>::DragDisk(Master& masterin, Grid<TF>& gridin, Fields<TF>& fieldsin, Input& input) :
+    master(masterin), grid(gridin), fields(fieldsin)
+{
+    sizex  = input.get_item<int>("dragdisk", "sizex", "", 0);
+    sizey  = input.get_item<int>("dragdisk", "sizey", "", 0);
+    height = input.get_item<TF>("dragdisk", "height", "", TF(0));
+    cd     = input.get_item<TF>("dragdisk", "cd", "", TF(0.2));
+    enabled = sizex > 0 && sizey > 0;
+    k_center = 0;
+}
+
+template<typename TF>
+DragDisk<TF>::~DragDisk()
+{
+}
+
+template<typename TF>
+void DragDisk<TF>::create()
+{
+    if (!enabled)
+        return;
+
+    auto& gd = grid.get_grid_data();
+
+    // Find vertical index closest to desired height
+    k_center = gd.kstart;
+    TF minz = std::abs(gd.z[gd.kstart] - height);
+    for (int k = gd.kstart + 1; k < gd.kend; ++k)
+    {
+        TF diff = std::abs(gd.z[k] - height);
+        if (diff < minz)
+        {
+            minz = diff;
+            k_center = k;
+        }
+    }
+
+    const int jj = gd.jstride;
+    const int kk = gd.kstride;
+
+    // Determine disk bounds centred in domain
+    int ic = gd.istart + (gd.iend - gd.istart) / 2;
+    int jc = gd.jstart + (gd.jend - gd.jstart) / 2;
+
+    int istart = std::max(gd.istart, ic - sizex / 2);
+    int iend   = std::min(gd.iend,   istart + sizex);
+    int jstart = std::max(gd.jstart, jc - sizey / 2);
+    int jend   = std::min(gd.jend,   jstart + sizey);
+
+    indices.clear();
+    for (int j = jstart; j < jend; ++j)
+        for (int i = istart; i < iend; ++i)
+            indices.push_back(i + j * jj + k_center * kk);
+}
+
+template<typename TF>
+void DragDisk<TF>::exec(Stats<TF>&, double)
+{
+    if (!enabled)
+        return;
+
+    auto& u = fields.mp.at("u")->fld;
+    for (int idx : indices)
+        u[idx] -= cd * u[idx];
+}
+
+template<typename TF>
+void DragDisk<TF>::prepare_device()
+{
+#ifdef USECUDA
+    dummy_g.allocate(1);
+#endif
+}
+
+template<typename TF>
+void DragDisk<TF>::clear_device()
+{
+#ifdef USECUDA
+    dummy_g.clear();
+#endif
+}
+
+#ifdef FLOAT_SINGLE
+template class DragDisk<float>;
+#else
+template class DragDisk<double>;
+#endif

--- a/src/model.cxx
+++ b/src/model.cxx
@@ -58,6 +58,7 @@
 #include "aerosol.h"
 #include "background_profs.h"
 #include "windfarm.h"
+#include "dragdisk.h"
 
 #ifdef USECUDA
 #include <cuda_runtime_api.h>
@@ -146,7 +147,7 @@ Model<TF>::Model(Master& masterin, int argc, char *argv[]) :
         background= std::make_shared<Background<TF>>(master, *grid, *fields, *input);
 
         particle_bin = std::make_shared<Particle_bin<TF>>(master, *grid, *fields, *input);
-
+        dragdisk  = std::make_shared<DragDisk<TF>>(master, *grid, *fields, *input);
         windfarm  = std::make_shared<Windfarm<TF>>(master, *grid, *fields, *input);
 
         ib        = std::make_shared<Immersed_boundary<TF>>(master, *grid, *fields, *input);
@@ -274,7 +275,7 @@ void Model<TF>::load()
     particle_bin->create(*timeloop);
     aerosol->create(*input, *input_nc, *stats);
     background->create(*input, *input_nc, *stats);
-
+    dragdisk->create();
     windfarm->create();
 
     microphys->create(*input, *input_nc, *stats, *cross, *dump, *column);
@@ -426,6 +427,9 @@ void Model<TF>::exec()
 
                 // Gravitational settling of binned dust types.
                 particle_bin->exec(*stats);
+
+                // Apply drag disk forcing
+                dragdisk->exec(*stats, timeloop->get_time());
 
                 // Apply turbine forcing from wind farm
                 windfarm->exec(*stats, timeloop->get_time());
@@ -602,6 +606,7 @@ void Model<TF>::prepare_gpu()
     ib       ->prepare_device();
     microphys->prepare_device();
     radiation->prepare_device();
+    dragdisk ->prepare_device();
     windfarm ->prepare_device();
     column   ->prepare_device();
     aerosol  ->prepare_device();
@@ -623,6 +628,7 @@ void Model<TF>::clear_gpu()
     ib       ->clear_device();
     microphys->clear_device();
     radiation->clear_device();
+    dragdisk ->clear_device();
     windfarm ->clear_device();
     column   ->clear_device();
     aerosol  ->clear_device();


### PR DESCRIPTION
## Summary
- introduce `DragDisk` class to apply linear drag to the streamwise velocity over a specified region
- integrate drag disk into model lifecycle and GPU hooks

## Testing
- `cmake -S . -B build && cmake --build build && ctest --test-dir build` *(fails: Config file config/default.cmake does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_689d0f484c18832ab14aa889c1235172